### PR TITLE
Bindings

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -24,7 +24,7 @@ import frc.robot.subsystems.SwerveSubsystem;
 
 import static frc.robot.Constants.Swerve.SQUARED_INPUTS;
 
-public class RobotContainer 
+public class RobotContainer {
   private CommandJoystick m_joystick = new CommandJoystick(0);
   private CommandXboxController m_controller = new CommandXboxController(1);
   

--- a/src/main/java/frc/robot/commands/DeployIntakeCommand.java
+++ b/src/main/java/frc/robot/commands/DeployIntakeCommand.java
@@ -9,7 +9,7 @@ import edu.wpi.first.wpilibj2.command.Subsystem;
 import frc.robot.subsystems.IntakeSubsystem;
 
 public class DeployIntakeCommand extends Command {
-  IntakeSubsystem m_intakesubsystem;
+  private IntakeSubsystem m_intakesubsystem;
   /** Creates a new DeployCommand. */
 
   public DeployIntakeCommand(IntakeSubsystem subsystem) {

--- a/src/main/java/frc/robot/commands/IntakeToOuttake.java
+++ b/src/main/java/frc/robot/commands/IntakeToOuttake.java
@@ -6,8 +6,9 @@ package frc.robot.commands;
 
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.subsystems.IntakeSubsystem;
+
 public class IntakeToOuttake extends Command {
-  IntakeSubsystem m_intakeSubsystem;
+private IntakeSubsystem m_intakeSubsystem;
   /** Creates a new IntakesOutake. */
   public IntakeToOuttake(IntakeSubsystem subsystem) {
     m_intakeSubsystem = subsystem;

--- a/src/main/java/frc/robot/commands/StowIntakeCommand.java
+++ b/src/main/java/frc/robot/commands/StowIntakeCommand.java
@@ -8,7 +8,7 @@ import edu.wpi.first.wpilibj2.command.Command;
 
 public class StowIntakeCommand extends Command {
   /** Creates a new ReverseDeployCommand. */
-  IntakeSubsystem m_intakeSubsystem;
+  private IntakeSubsystem m_intakeSubsystem;
   public StowIntakeCommand(IntakeSubsystem subsystem) {
     m_intakeSubsystem = subsystem;
     addRequirements(subsystem);

--- a/src/main/java/frc/robot/subsystems/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/IntakeSubsystem.java
@@ -22,6 +22,10 @@ import frc.robot.commands.StowIntakeCommand;
 
 import static frc.robot.Constants.Intake.*;
 
+import java.util.function.BooleanSupplier;
+
+import javax.swing.text.StyledEditorKit.BoldAction;
+
 
 public class IntakeSubsystem extends SubsystemBase {
 
@@ -125,8 +129,8 @@ public class IntakeSubsystem extends SubsystemBase {
     m_pivotPID.setGoal(STOW_SETPOINT);
   }
 
-  public Command getReelCommand() {
-    return new ReelCommand(this);
+  public Command getReelCommand(BooleanSupplier cancel) {
+    return new ReelCommand(this, cancel);
   }
 
   public Command getDeployCommand() {

--- a/src/main/java/frc/robot/subsystems/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/IntakeSubsystem.java
@@ -12,7 +12,12 @@ import edu.wpi.first.math.controller.ProfiledPIDController;
 import edu.wpi.first.math.trajectory.TrapezoidProfile;
 import edu.wpi.first.wpilibj.DigitalInput;
 import edu.wpi.first.wpilibj.Encoder;
+import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.commands.DeployIntakeCommand;
+import frc.robot.commands.IntakeToOuttake;
+import frc.robot.commands.ReelCommand;
+import frc.robot.commands.StowIntakeCommand;
 
 import static frc.robot.Constants.Intake.*;
 
@@ -114,8 +119,20 @@ public class IntakeSubsystem extends SubsystemBase {
     m_pivotPID.setGoal(STOW_SETPOINT);
   }
 
+  public Command getReelCommand() {
+    return new ReelCommand(this);
+  }
 
+  public Command getDeployCommand() {
+    return new DeployIntakeCommand(this);
+  }
 
-  
+  public Command getStowCommand() {
+    return new StowIntakeCommand(this);
+  }
+
+  public Command getToOuttakeCommand() {
+    return new IntakeToOuttake(this);
+  }
   
 }

--- a/src/main/java/frc/robot/subsystems/OuttakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/OuttakeSubsystem.java
@@ -35,6 +35,8 @@ public class OuttakeSubsystem extends SubsystemBase {
   public OuttakeSubsystem() {
     m_shooterMotorI.follow(m_shooterMotorII);
     m_shooterMotorI.setInverted(SHOOTER_MOTOR_I_INVERTED);
+
+    m_pivotEncoder.setPosition(0);
   }
 
   @Override
@@ -51,8 +53,12 @@ public class OuttakeSubsystem extends SubsystemBase {
     }
   }
 
-  public boolean isAtAmpPosition() {
+  public boolean ampLimitSwitchHit() {
     return m_ampLimitSwitch.get();
+  }
+
+  public boolean isInAmpPosition() {
+    return m_pivotEncoder.getPosition() < SPEAKER_POSITION / 2.0;
   }
 
   public void toSpeakerPosition() {

--- a/src/main/java/frc/robot/subsystems/OuttakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/OuttakeSubsystem.java
@@ -82,7 +82,7 @@ public class OuttakeSubsystem extends SubsystemBase {
     return run(() -> rollOuttake(TAKE_NOTE_SPEAKER_MOTOR_VOLTAGE, SHOOTER_SPEAKER_MOTOR_VOLTAGE));
   }
 
-  public Command YoinkNoteCommand() {
+  public Command yoinkNoteCommand() {
     return run(() -> rollOuttake(YOINK_TAKE_NOTE_SPEED, YOINK_SHOOTERS_SPEED));
   }
 


### PR DESCRIPTION
Uses the commands created by all other subsystems to create sequential commands that get binded to buttons on the joystick.
Some highlights...

Button 11: deploy intake, reel note until note limit switch hit, stow intake
Button 10: deploy intake and outtake to amp position, then climber retracts
Button 3: run intake and outtake to pass off note, then rotate outtake to amp position
trigger: run outtake slowly if outtake in amp position, run outtake and intake simultaneously and quickly if outtake in speaker position